### PR TITLE
[BISERVER-13068] - JPivot plugin - wrong sorting of dimension members on JRE 1.7+

### DIFF
--- a/jpivot-src-mods/jpivot/src/java/com/tonbeller/jpivot/MemberVisibilityAwareComparator.java
+++ b/jpivot-src-mods/jpivot/src/java/com/tonbeller/jpivot/MemberVisibilityAwareComparator.java
@@ -1,0 +1,56 @@
+/*!
+* This program is free software; you can redistribute it and/or modify it under the
+* terms of the GNU Lesser General Public License, version 2.1 as published by the Free Software
+* Foundation.
+*
+* You should have received a copy of the GNU Lesser General Public License along with this
+* program; if not, you can obtain a copy at http://www.gnu.org/licenses/old-licenses/lgpl-2.1.html
+* or from the Free Software Foundation, Inc.,
+* 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+*
+* This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+* without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+* See the GNU Lesser General Public License for more details.
+*
+* Copyright (c) 2002-2016 Pentaho Corporation..  All rights reserved.
+*/
+
+package com.tonbeller.jpivot;
+
+import java.util.Comparator;
+import java.util.List;
+
+/**
+ * This class is used to fix a bug in JPivot. The bug is about determining the correct index when sorting members using
+ * a list of visible elements.
+ *
+ * @author Andrey Khayrutdinov
+ */
+public class MemberVisibilityAwareComparator<Member> implements Comparator<Member> {
+
+  private final List<Member> visible;
+
+  public MemberVisibilityAwareComparator( List<Member> visible ) {
+    // deliberately neglect making a defensive copy
+    this.visible = visible;
+  }
+
+  @Override
+  public int compare( Member m1, Member m2 ) {
+    int index1 = visible.indexOf( m1 );
+    int index2 = visible.indexOf( m2 );
+    if ( index1 == -1 ) {
+      if ( index2 == -1 ) {
+        return 0;
+      } else {
+        return 1; // m1 is higher, unvisible to the end
+      }
+    } else {
+      if ( index2 == -1 ) {
+        return -1; // m2 is higher, unvisible to the end
+      } else {
+        return index1 - index2;
+      }
+    }
+  }
+}

--- a/jpivot-src-mods/jpivot/src/java/com/tonbeller/jpivot/mondrian/MondrianMemberTree.java
+++ b/jpivot-src-mods/jpivot/src/java/com/tonbeller/jpivot/mondrian/MondrianMemberTree.java
@@ -14,10 +14,10 @@ package com.tonbeller.jpivot.mondrian;
 
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Comparator;
 import java.util.Iterator;
 import java.util.List;
 
+import com.tonbeller.jpivot.MemberVisibilityAwareComparator;
 import mondrian.olap.ResultLimitExceededException;
 import mondrian.olap.SchemaReader;
 
@@ -146,20 +146,8 @@ public class MondrianMemberTree extends ExtensionSupport implements MemberTree {
     Member[] members = (Member[]) aMem.toArray(new Member[0]);
 
     // If there is no query result, do not sort
-    if (!visibleRootMembers.isEmpty()) {
-      Arrays.sort(members, new Comparator() {
-        public int compare(Object arg0, Object arg1) {
-          Member m1 = (Member) arg0;
-          Member m2 = (Member) arg1;
-          int index1 = visibleRootMembers.indexOf(m1);
-          int index2 = visibleRootMembers.indexOf(m2);
-          if (index2 == -1)
-            return -1; // m2 is higher, unvisible to the end
-          if (index1 == -1)
-            return 1; // m1 is higher, unvisible to the end
-          return index1 - index2;
-        }
-      });
+    if ( !visibleRootMembers.isEmpty() ) {
+      Arrays.sort( members, new MemberVisibilityAwareComparator<Member>( visibleRootMembers ) );
     }
 
     return members;
@@ -306,20 +294,8 @@ public class MondrianMemberTree extends ExtensionSupport implements MemberTree {
     }
     Member[] children = (Member[]) list.toArray(new Member[list.size()]);
 
-    if (res!=null){  //turned off
-      Arrays.sort(children, new Comparator() {
-        public int compare(Object arg0, Object arg1) {
-          Member m1 = (Member) arg0;
-          Member m2 = (Member) arg1;
-          int index1 = visibleChildMembers.indexOf(m1);
-          int index2 = visibleChildMembers.indexOf(m2);
-          if (index2 == -1)
-            return -1; // m2 is higher, unvisible to the end
-          if (index1 == -1)
-            return 1; // m1 is higher, unvisible to the end
-          return index1 - index2;
-        }
-      });
+    if ( res != null ) {  //turned off
+      Arrays.sort( children, new MemberVisibilityAwareComparator<Member>( visibleChildMembers ) );
     }
 
     return children;

--- a/jpivot-src-mods/jpivot/src/java/com/tonbeller/jpivot/mondrian/MondrianMemberTree.java
+++ b/jpivot-src-mods/jpivot/src/java/com/tonbeller/jpivot/mondrian/MondrianMemberTree.java
@@ -1,0 +1,345 @@
+/*
+ * ====================================================================
+ * This software is subject to the terms of the Common Public License
+ * Agreement, available at the following URL:
+ *   http://www.opensource.org/licenses/cpl.html .
+ * Copyright (C) 2003-2004 TONBELLER AG.
+ * All Rights Reserved.
+ * You must accept the terms of that agreement to use this software.
+ * ====================================================================
+ *
+ *
+ */
+package com.tonbeller.jpivot.mondrian;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Comparator;
+import java.util.Iterator;
+import java.util.List;
+
+import mondrian.olap.ResultLimitExceededException;
+import mondrian.olap.SchemaReader;
+
+import org.apache.log4j.Logger;
+
+import com.tonbeller.jpivot.core.ExtensionSupport;
+import com.tonbeller.jpivot.olap.model.Axis;
+import com.tonbeller.jpivot.olap.model.Hierarchy;
+import com.tonbeller.jpivot.olap.model.Member;
+import com.tonbeller.jpivot.olap.model.Position;
+import com.tonbeller.jpivot.olap.model.Result;
+import com.tonbeller.jpivot.olap.navi.MemberTree;
+import com.tonbeller.jpivot.olap.query.Quax;
+
+/**
+ * Implementation of the DrillExpand Extension for Mondrian Data Source.
+ */
+public class MondrianMemberTree extends ExtensionSupport implements MemberTree {
+
+  static Logger logger = Logger.getLogger(MondrianMemberTree.class);
+
+  /**
+   * Constructor sets ID
+   */
+  public MondrianMemberTree() {
+    super.setId(MemberTree.ID);
+  }
+
+  /**
+   * @return the root members of a hierarchy. This is for example the "All"
+   *         member or the list of measures.
+   */
+  public Member[] getRootMembers(Hierarchy hier) {
+    try {
+      return internalGetRootMembers(hier);
+    } catch (ResultLimitExceededException e) {
+      logger.error(null, e);
+      throw new TooManyMembersException(e);
+    }
+  }
+
+  private Member[] internalGetRootMembers(Hierarchy hier) {
+    MondrianModel model = (MondrianModel) getModel();
+    mondrian.olap.Hierarchy monHier = ((MondrianHierarchy) hier).getMonHierarchy();
+    mondrian.olap.Query q = ((MondrianQueryAdapter) model.getQueryAdapter()).getMonQuery();
+    // Use the schema reader from the query, because it contains calculated
+    // members defined in both the cube and the query.
+    SchemaReader scr = model.getSchemaReader();
+    List<mondrian.olap.Member> monMembers = scr.getHierarchyRootMembers(monHier);
+    ArrayList aMem = new ArrayList();
+    final List visibleRootMembers = new ArrayList();
+    int k = monMembers.size();
+    for (int i = 0; i < k; i++) {
+      mondrian.olap.Member monMember = (mondrian.olap.Member) monMembers.get(i);
+      if (isVisible(monMember)) {
+        aMem.add(model.addMember(monMember));
+      }
+    }
+
+
+    // find the calculated members for this hierarchy
+    //  show them together with root level members
+    mondrian.olap.Formula[] formulas = q.getFormulas();
+    for (int i = 0; i < formulas.length; i++) {
+      mondrian.olap.Formula f = formulas[i];
+      mondrian.olap.Member monMem = f.getMdxMember();
+      if (monMem != null) {
+        // is the member for this hierarchy,
+        // and is it visible?
+        // if yes add it
+        if (monMem.getHierarchy().equals(monHier)) {
+          if (!isVisible(monMem))
+            continue;
+          // ADVR MOD 2008.12.15
+          // Changed to only add root calculated members (parent==null) to the root.
+          // Other members will be added at the correct place within the
+          // respective hierarchy
+
+          // find the parent for this member
+          if (monMem.getParentMember()== null){
+            Member m = model.addMember(monMem);
+            if (!aMem.contains(m))
+              aMem.add(m);
+          }
+        }
+      }
+    }
+
+    // order members according to occurrence in query result
+    //  if there is no result available, do not sort
+    Result res = model.currentResult();
+    if (res != null) {
+      // locate the appropriate result axis
+      // find the Quax for this hier
+      MondrianQueryAdapter adapter = (MondrianQueryAdapter) model.getQueryAdapter();
+      Quax quax = adapter.findQuax(hier.getDimension());
+      if (quax != null) {
+        int iDim = quax.dimIdx(hier.getDimension());
+        int iAx = quax.getOrdinal();
+        if (adapter.isSwapAxes())
+          iAx = (iAx + 1) % 2;
+        Axis axis = res.getAxes()[iAx];
+        List positions = axis.getPositions();
+
+        for (Iterator iter = positions.iterator(); iter.hasNext();) {
+          Position pos = (Position) iter.next();
+          Member[] posMembers = pos.getMembers();
+          MondrianMember mem = (MondrianMember) posMembers[iDim];
+          // only add hierarchy items from the query results
+          // if they are actually in in the currently expanding hierarchy!!
+          if (mem.getMonMember().getHierarchy().equals(monHier)) {
+            if (!(mem.getMonMember().getParentMember() == null))
+              continue; // ignore, not root
+            if (!visibleRootMembers.contains(mem))
+              visibleRootMembers.add(mem);
+
+            // Check if the result axis contains invisible members
+            if (!aMem.contains(mem)) {
+              aMem.add(mem);
+            }
+          }
+        }
+      }
+    }
+
+    Member[] members = (Member[]) aMem.toArray(new Member[0]);
+
+    // If there is no query result, do not sort
+    if (!visibleRootMembers.isEmpty()) {
+      Arrays.sort(members, new Comparator() {
+        public int compare(Object arg0, Object arg1) {
+          Member m1 = (Member) arg0;
+          Member m2 = (Member) arg1;
+          int index1 = visibleRootMembers.indexOf(m1);
+          int index2 = visibleRootMembers.indexOf(m2);
+          if (index2 == -1)
+            return -1; // m2 is higher, unvisible to the end
+          if (index1 == -1)
+            return 1; // m1 is higher, unvisible to the end
+          return index1 - index2;
+        }
+      });
+    }
+
+    return members;
+  }
+
+  private boolean isVisible(mondrian.olap.Member monMember) {
+    // Name convention: if member starts with "." its hidden
+    if (monMember.getName().startsWith("."))
+      return false;
+
+    MondrianModel model = (MondrianModel) getModel();
+    // Use the schema reader from the query, because it contains calculated
+    // members defined in both the cube and the query.
+    SchemaReader scr = model.getSchemaReader();
+
+    return MondrianUtil.isVisible(scr, monMember);
+  }
+
+  /**
+   * @return true if the member has children
+   */
+  public boolean hasChildren(Member member) {
+    mondrian.olap.Member monMember = ((MondrianMember) member).getMonMember();
+    if (monMember.isCalculatedInQuery())
+      return false;
+
+    if (monMember.getLevel().getChildLevel() != null){
+      if (!monMember.isCalculated()) return true;
+      // ADVR 2010.07.27
+      // for calculated we need to actually check if there are any children.
+      return this.getChildren(member).length!=0;
+
+    }
+
+    // here for a leaf-level, but also for a level in a parent-child hierarchy:
+    MondrianModel model = (MondrianModel) getModel();
+
+    SchemaReader scr = model.getSchemaReader();
+    return scr.isDrillable(monMember);
+  }
+
+  /**
+   * @return the children of the member
+   */
+  public Member[] getChildren(Member member) {
+    try {
+      return internalGetChildren(member);
+    } catch (ResultLimitExceededException e) {
+      logger.error(null, e);
+      throw new TooManyMembersException(e);
+    }
+  }
+
+  private Member[] internalGetChildren(Member member) {
+    mondrian.olap.Member monMember = ((MondrianMember) member).getMonMember();
+    //  unreliable: always null in a parent-child hierarch
+    // if (monMember.getLevel().getChildLevel() == null)
+    //   return null;
+
+    MondrianModel model = (MondrianModel) getModel();
+
+    SchemaReader scr = model.getSchemaReader();
+    List<mondrian.olap.Member> monChildren = scr.getMemberChildren(monMember);
+
+    List list = new ArrayList(monChildren.size());
+    for (int i = 0; i < monChildren.size(); i++) {
+      mondrian.olap.Member m = (mondrian.olap.Member)monChildren.get(i);
+      if (MondrianUtil.isVisible(scr, m)) {
+        list.add(model.addMember(m));
+      }
+    }
+
+    // ADVR MOD 2008.12.15
+    // check for calculated members that belong to this level
+
+    mondrian.olap.Query q = ((MondrianQueryAdapter) model.getQueryAdapter()).getMonQuery();
+
+    // find the calculated members for this hierarchy
+    //  show them together with level members
+    mondrian.olap.Formula[] formulas = q.getFormulas();
+    for (int i = 0; i < formulas.length; i++) {
+      mondrian.olap.Formula f = formulas[i];
+      mondrian.olap.Member monMem = f.getMdxMember();
+      if (monMem != null) {
+        // is the member for this hierarchy,
+        // and is it visible?
+        // if yes add it
+        if (!isVisible(monMem))
+          continue;
+        if (monMem.getDimension().equals(monMember.getDimension()) &&
+          monMem.getHierarchy().equals(monMember.getHierarchy())) {
+
+          // If this calculated member is a child of this current member,
+          //  add it to the child list
+          if ( monMem.getParentMember().equals(monMember)){
+            Member m = model.addMember(monMem);
+            if (!list.contains(m))
+              list.add(m);
+          }
+        }
+      }
+    }
+    // ADVR 2010.07.20
+    // order the children by order of appearance in Query result
+    //  if there is no result available, do not sort
+    Result res = model.currentResult();
+    final List visibleChildMembers = new ArrayList();
+    if (res != null) {
+      // locate the appropriate result axis
+      // find the Quax for this hier
+      MondrianQueryAdapter adapter = (MondrianQueryAdapter) model.getQueryAdapter();
+      mondrian.olap.Hierarchy monHier = monMember.getHierarchy();
+      Hierarchy hier = member.getLevel().getHierarchy();
+
+      Quax quax = adapter.findQuax(hier.getDimension());
+      if (quax != null) {
+        int iDim = quax.dimIdx(hier.getDimension());
+        int iAx = quax.getOrdinal();
+        if (adapter.isSwapAxes())
+          iAx = (iAx + 1) % 2;
+        Axis axis = res.getAxes()[iAx];
+        List positions = axis.getPositions();
+
+        for (Iterator iter = positions.iterator(); iter.hasNext();) {
+          Position pos = (Position) iter.next();
+          Member[] posMembers = pos.getMembers();
+          MondrianMember mem = (MondrianMember) posMembers[iDim];
+          // only add hierarchy items from the query results
+          // if they are actually in in the currently expanding hierarchy!!
+          if (mem.getMonMember().getParentMember()==null)
+            continue; // skip root members - can't be children
+          if (mem.getMonMember().getHierarchy().equals(monHier)) {
+            if (mem.getMonMember().getParentMember().equals(monMember)){
+              visibleChildMembers.add(mem);
+
+              // Check if the result axis contains invisible members
+              if (!list.contains(mem)) {
+                list.add(mem);
+              }
+            }
+          }
+        }
+      }
+    }
+    Member[] children = (Member[]) list.toArray(new Member[list.size()]);
+
+    if (res!=null){  //turned off
+      Arrays.sort(children, new Comparator() {
+        public int compare(Object arg0, Object arg1) {
+          Member m1 = (Member) arg0;
+          Member m2 = (Member) arg1;
+          int index1 = visibleChildMembers.indexOf(m1);
+          int index2 = visibleChildMembers.indexOf(m2);
+          if (index2 == -1)
+            return -1; // m2 is higher, unvisible to the end
+          if (index1 == -1)
+            return 1; // m1 is higher, unvisible to the end
+          return index1 - index2;
+        }
+      });
+    }
+
+    return children;
+  }
+
+  /**
+   * @return the parent of member or null, if this is a root member
+   */
+  public Member getParent(Member member) {
+    mondrian.olap.Member monMember = ((MondrianMember) member).getMonMember();
+
+    MondrianModel model = (MondrianModel) getModel();
+
+    SchemaReader scr = model.getSchemaReader();
+    mondrian.olap.Member monParent = scr.getMemberParent(monMember);
+    if (monParent == null)
+      return null; // already top level
+    Member parent = model.addMember(monParent);
+
+    return parent;
+  }
+
+} // End MondrianMemberTree

--- a/jpivot-src-mods/jpivot/src/java/com/tonbeller/jpivot/xmla/XMLA_MemberTree.java
+++ b/jpivot-src-mods/jpivot/src/java/com/tonbeller/jpivot/xmla/XMLA_MemberTree.java
@@ -14,10 +14,10 @@ package com.tonbeller.jpivot.xmla;
 
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Comparator;
 import java.util.Iterator;
 import java.util.List;
 
+import com.tonbeller.jpivot.MemberVisibilityAwareComparator;
 import org.apache.log4j.Logger;
 
 import com.tonbeller.jpivot.core.ExtensionSupport;
@@ -160,20 +160,8 @@ public class XMLA_MemberTree extends ExtensionSupport implements MemberTree {
     }
 
     // If there is no query result, do not sort
-    if (visibleRootMembers.size() != 0) {
-      Arrays.sort(members, new Comparator() {
-        public int compare(Object arg0, Object arg1) {
-          Member m1 = (Member) arg0;
-          Member m2 = (Member) arg1;
-          int index1 = visibleRootMembers.indexOf(m1);
-          int index2 = visibleRootMembers.indexOf(m2);
-          if (index2 == -1)
-            return -1; // m2 is higher, unvisible to the end
-          if (index1 == -1)
-            return 1; // m1 is higher, unvisible to the end
-          return index1 - index2;
-        }
-      });
+    if ( !visibleRootMembers.isEmpty() ) {
+      Arrays.sort( members, new MemberVisibilityAwareComparator<Member>( visibleRootMembers ) );
     }
 
     return members;

--- a/jpivot-src-mods/jpivot/src/java/com/tonbeller/jpivot/xmla/XMLA_MemberTree.java
+++ b/jpivot-src-mods/jpivot/src/java/com/tonbeller/jpivot/xmla/XMLA_MemberTree.java
@@ -1,0 +1,240 @@
+/*
+ * ====================================================================
+ * This software is subject to the terms of the Common Public License
+ * Agreement, available at the following URL:
+ *   http://www.opensource.org/licenses/cpl.html .
+ * Copyright (C) 2003-2004 TONBELLER AG.
+ * All Rights Reserved.
+ * You must accept the terms of that agreement to use this software.
+ * ====================================================================
+ *
+ * 
+ */
+package com.tonbeller.jpivot.xmla;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Comparator;
+import java.util.Iterator;
+import java.util.List;
+
+import org.apache.log4j.Logger;
+
+import com.tonbeller.jpivot.core.ExtensionSupport;
+import com.tonbeller.jpivot.olap.mdxparse.Formula;
+import com.tonbeller.jpivot.olap.mdxparse.ParsedQuery;
+import com.tonbeller.jpivot.olap.model.Hierarchy;
+import com.tonbeller.jpivot.olap.model.Level;
+import com.tonbeller.jpivot.olap.model.Member;
+import com.tonbeller.jpivot.olap.model.OlapException;
+import com.tonbeller.jpivot.olap.navi.MemberTree;
+import com.tonbeller.jpivot.util.StringUtil;
+import com.tonbeller.jpivot.olap.model.Position;
+import com.tonbeller.jpivot.olap.model.Result;
+import com.tonbeller.jpivot.olap.query.Quax;
+import com.tonbeller.jpivot.olap.model.Axis;
+
+/**
+ * Member Tree Implementation vor XMLA
+ */
+public class XMLA_MemberTree extends ExtensionSupport implements MemberTree {
+
+  static Logger logger = Logger.getLogger(XMLA_MemberTree.class);
+
+  /**
+   * Constructor sets ID
+   */
+  public XMLA_MemberTree() {
+    super.setId(MemberTree.ID);
+  }
+
+  /**
+   * @return the root members of a hierarchy. This is for example
+   * the "All" member or the list of measures.
+   */
+  public Member[] getRootMembers(Hierarchy hier) {
+    XMLA_Model model = (XMLA_Model) getModel();
+    Level[] levels = hier.getLevels();
+    // get root level
+    XMLA_Level rootLevel = null;
+    for (int i = 0; i < levels.length; i++) {
+      XMLA_Level xLev = (XMLA_Level) levels[i];
+      if (xLev.getDepth() == 0) {
+        rootLevel = xLev;
+        break;
+      }
+    }
+    if (rootLevel == null)
+      return null; // should not occur
+
+
+    final List visibleRootMembers = new ArrayList();
+    final List invisibleRootMembers = new ArrayList();
+
+    Member[] rootMembers = new Member[0];
+    try {
+      rootMembers = rootLevel.getMembers();
+    } catch (OlapException e) {
+      logger.error(null, e);
+    }
+    // find the calculated members for this hierarchy
+    //  show them together with root level members
+    ArrayList aCalcMem = new ArrayList();
+    ParsedQuery pq = ((XMLA_QueryAdapter) model.getQueryAdapter()).getParsedQuery();
+    Formula[] formulas = pq.getFormulas();
+
+    for (int i = 0; i < formulas.length; i++) {
+      Formula f = formulas[i];
+      if (!f.isMember())
+        continue;
+
+      String dimUMember = StringUtil.bracketsAround(f.getFirstName());
+      String dimUHier = ((XMLA_Hierarchy) hier).getUniqueName();
+      if (!(dimUHier.equals(dimUMember)))
+        continue;
+
+      String memberName = f.getUniqeName();
+      XMLA_Member calcMem = (XMLA_Member) model.lookupMemberByUName(memberName);
+      if (calcMem == null) {
+          /* Strip brackets from name */
+        String[] nameParts = StringUtil.splitUniqueName(memberName);
+        calcMem = new XMLA_Member(model, memberName, nameParts[1], null, true);
+        //calcMem = new XMLA_Member(model, memberName, f.getLastName(), null, true);
+      }
+      aCalcMem.add(calcMem);
+    }
+
+    // order members according to occurrence in query result
+    //  if there is no result available, do not sort
+    // If the result contains invisible members, add them to the list
+    Result res = model.currentResult();
+    if (res != null) {
+      // locate the appropriate result axis
+      // find the Quax for this hier
+      XMLA_QueryAdapter adapter = (XMLA_QueryAdapter) model.getQueryAdapter();
+      Quax quax = adapter.findQuax(hier.getDimension());
+      if (quax != null) {
+        int iDim = quax.dimIdx(hier.getDimension());
+        int iAx = quax.getOrdinal();
+        if (adapter.isSwapAxes())
+          iAx = (iAx + 1) % 2;
+        Axis axis = res.getAxes()[iAx];
+        List positions = axis.getPositions();
+
+        for (Iterator iter = positions.iterator(); iter.hasNext();) {
+          Position pos = (Position) iter.next();
+          Member[] posMembers = pos.getMembers();
+          XMLA_Member mem = (XMLA_Member) posMembers[iDim];
+          if (!(getParent(mem) == null))
+            continue; // ignore, not root
+          if (!visibleRootMembers.contains(mem))
+            visibleRootMembers.add(mem);
+
+          // Check if the result axis contains invisible members
+          boolean containsMember = false;
+          for (int i = 0; i < rootMembers.length; i++) {
+            if (rootMembers[i].equals(mem)) {
+              containsMember = true;
+              break;
+            }
+          }
+          if (!containsMember && !aCalcMem.contains(mem) && !invisibleRootMembers.contains(mem)) {
+            invisibleRootMembers.add(mem);
+          }
+        }
+      }
+    }
+
+    Member[] members = new Member[rootMembers.length + aCalcMem.size() + invisibleRootMembers.size()];
+    int k = rootMembers.length;
+    for (int i = 0; i < k; i++) {
+      members[i] = rootMembers[i];
+    }
+    for (Iterator iter = aCalcMem.iterator(); iter.hasNext();) {
+      XMLA_Member calcMem = (XMLA_Member) iter.next();
+      members[k++] = calcMem;
+    }
+    for (Iterator iter = invisibleRootMembers.iterator(); iter.hasNext();) {
+      XMLA_Member invisibleMem = (XMLA_Member) iter.next();
+      members[k++] = invisibleMem;
+    }
+
+    // If there is no query result, do not sort
+    if (visibleRootMembers.size() != 0) {
+      Arrays.sort(members, new Comparator() {
+        public int compare(Object arg0, Object arg1) {
+          Member m1 = (Member) arg0;
+          Member m2 = (Member) arg1;
+          int index1 = visibleRootMembers.indexOf(m1);
+          int index2 = visibleRootMembers.indexOf(m2);
+          if (index2 == -1)
+            return -1; // m2 is higher, unvisible to the end
+          if (index1 == -1)
+            return 1; // m1 is higher, unvisible to the end
+          return index1 - index2;
+        }
+      });
+    }
+
+    return members;
+  }
+
+  /**
+   * @return true if the member has children
+   */
+  public boolean hasChildren(Member member) {
+
+    XMLA_Member m = (XMLA_Member) member;
+    if (m.isCalculated())
+      return false;
+    long ccard = m.getChildrenCardinality(); // -1 if not initialized
+    if (ccard >= 0)
+      return (ccard > 0);
+    XMLA_Level xLev = (XMLA_Level) member.getLevel();
+    if (xLev == null || xLev.getChildLevel() == null)
+      return false;
+    return true;
+  }
+
+  /**
+   * @return the children of the member
+   */
+  public Member[] getChildren(Member member) {
+
+    XMLA_Level xLev = (XMLA_Level) member.getLevel();
+
+    if (xLev == null || xLev.getChildLevel() == null)
+      return null;
+
+    Member[] children = new Member[0];
+    try {
+      children = ((XMLA_Member) member).getChildren();
+    } catch (OlapException e) {
+      logger.error("?", e);
+      return null;
+    }
+    return children;
+  }
+
+  /**
+   * @return the parent of member or null, if this is a root member
+   */
+  public Member getParent(Member member) {
+
+    XMLA_Level xLev = (XMLA_Level) member.getLevel();
+
+    if (xLev == null || xLev.getDepth() == 0)
+      return null; // already top level
+
+    XMLA_Member parent = null;
+    try {
+      parent = (XMLA_Member) ((XMLA_Member) member).getParent();
+    } catch (OlapException e) {
+      logger.error("?", e);
+      return null;
+    }
+
+    return parent;
+  }
+
+} // End XMLA_MemberTree


### PR DESCRIPTION
@pamval, @lucboudreau, review it please.
I separated changes into two commits. The first simply introduces two classes in the repository. The seconds changes comparators, that are used.

Once you merged this PR, please close https://github.com/pentaho/pentaho-platform-plugin-jpivot/pull/35