### PR TITLE
[BISERVER-13068] JPivot plugin - wrong sorting of dimension members o…

### DIFF
--- a/build.properties
+++ b/build.properties
@@ -8,5 +8,5 @@ dependency.mondrian.revision=3.13-SNAPSHOT
 dependency.pentaho-actionsequence-dom.revision=7.0-SNAPSHOT
 dependency.pentaho-platform.revision=7.0-SNAPSHOT
 dependency.pentaho.repository.revision=7.0-SNAPSHOT
-dependency.jpivot.revision=1.8.0-130701
+dependency.jpivot.revision=1.8.0-280316
 dependency.wcf.revision=1.8.0-130820


### PR DESCRIPTION
…n JRE 1.7+

- updated JPivot dependency to the one with fixed sorting