### PR TITLE
[BACKLOG-11322] Resolve Security Vulnerabilities around Apache Common File Upload

### DIFF
--- a/ivy.xml
+++ b/ivy.xml
@@ -36,7 +36,7 @@
     <exclude org="commons-fileupload" name="commons-fileupload"/>
     </dependency>
     <dependency org="commons-fileupload" name="commons-fileupload"
-        rev="1.3.1" transitive="false"/>
+        rev="1.3.2" transitive="false"/>
 
 
       <!--  internal dependencies -->


### PR DESCRIPTION
@pentaho/rogueone Upgrade to commons-fileupload-1.3.2. Please review.
