### PR TITLE
[SP-2953] - Backport of PPP-3560 - Use of vulnerable component taglibs:standard:1.0.6 CVE-2015-0254 (6.1 Suite)

### DIFF
--- a/ivy.xml
+++ b/ivy.xml
@@ -29,8 +29,8 @@
     <dependency org="javax.servlet" name="servlet-api" rev="2.4"/>
     <dependency org="javax.servlet" name="jsp-api" rev="2.0"/>
     <dependency org="javax.servlet" name="jstl" rev="1.0.5"/>
-	<dependency org="org.apache.tomcat" name="jasper" rev="6.0.36" transitive="false"/>
-	<dependency org="jakarta-taglibs" name="standard" rev="1.0.6" transitive="false"/> 
+    <dependency org="org.apache.tomcat" name="jasper" rev="6.0.36" transitive="false"/>
+    <dependency org="org.apache.taglibs" name="taglibs-standard-impl" rev="1.2.5" transitive="false"/>
     <!-- ESAPI -->
     <dependency org="org.owasp.esapi" name="esapi" rev="2.0.1" transitive="false">
     <exclude org="commons-fileupload" name="commons-fileupload"/>

--- a/src/org/pentaho/jpivot/PivotBusy_jsp.java
+++ b/src/org/pentaho/jpivot/PivotBusy_jsp.java
@@ -109,7 +109,7 @@ public final class PivotBusy_jsp extends org.apache.jasper.runtime.HttpJspBase
     PageContext pageContext = _jspx_page_context;
     JspWriter out = _jspx_page_context.getOut();
     //  c:out
-    org.apache.taglibs.standard.tag.el.core.OutTag _jspx_th_c_005fout_005f0 = (org.apache.taglibs.standard.tag.el.core.OutTag) _005fjspx_005ftagPool_005fc_005fout_0026_005fvalue_005fnobody.get(org.apache.taglibs.standard.tag.el.core.OutTag.class);
+    org.apache.taglibs.standard.tag.rt.core.OutTag _jspx_th_c_005fout_005f0 = (org.apache.taglibs.standard.tag.rt.core.OutTag) _005fjspx_005ftagPool_005fc_005fout_0026_005fvalue_005fnobody.get(org.apache.taglibs.standard.tag.rt.core.OutTag.class);
     _jspx_th_c_005fout_005f0.setPageContext(_jspx_page_context);
     _jspx_th_c_005fout_005f0.setParent(null);
     // /jsp/PivotBusy.jsp(9,45) name = value type = java.lang.String reqTime = false required = true fragment = false deferredValue = false expectedTypeName = null deferredMethod = false methodSignature = null
@@ -128,7 +128,7 @@ public final class PivotBusy_jsp extends org.apache.jasper.runtime.HttpJspBase
     PageContext pageContext = _jspx_page_context;
     JspWriter out = _jspx_page_context.getOut();
     //  c:out
-    org.apache.taglibs.standard.tag.el.core.OutTag _jspx_th_c_005fout_005f1 = (org.apache.taglibs.standard.tag.el.core.OutTag) _005fjspx_005ftagPool_005fc_005fout_0026_005fvalue_005fnobody.get(org.apache.taglibs.standard.tag.el.core.OutTag.class);
+    org.apache.taglibs.standard.tag.rt.core.OutTag _jspx_th_c_005fout_005f1 = (org.apache.taglibs.standard.tag.rt.core.OutTag) _005fjspx_005ftagPool_005fc_005fout_0026_005fvalue_005fnobody.get(org.apache.taglibs.standard.tag.rt.core.OutTag.class);
     _jspx_th_c_005fout_005f1.setPageContext(_jspx_page_context);
     _jspx_th_c_005fout_005f1.setParent(null);
     // /jsp/PivotBusy.jsp(16,11) name = value type = java.lang.String reqTime = false required = true fragment = false deferredValue = false expectedTypeName = null deferredMethod = false methodSignature = null

--- a/src/org/pentaho/jpivot/PivotBusy_jsp.java
+++ b/src/org/pentaho/jpivot/PivotBusy_jsp.java
@@ -12,7 +12,7 @@
 * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
 * See the GNU Lesser General Public License for more details.
 *
-* Copyright 2013 Pentaho Corporation.  All rights reserved.
+* Copyright 2016 Pentaho Corporation.  All rights reserved.
 *
 * This servlet is source generated from Tomcat's JSP generator, based on PivotBusy.jsp.  This
 * specific file was generated in 4.8 GA.
@@ -20,9 +20,15 @@
 
 package org.pentaho.jpivot;
 
-import javax.servlet.*;
-import javax.servlet.http.*;
-import javax.servlet.jsp.*;
+import javax.servlet.ServletException;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import javax.servlet.jsp.JspFactory;
+import javax.servlet.jsp.JspWriter;
+import javax.servlet.jsp.PageContext;
+import javax.servlet.jsp.SkipPageException;
+
 import org.pentaho.platform.util.messages.LocaleHelper;
 
 public final class PivotBusy_jsp extends org.apache.jasper.runtime.HttpJspBase
@@ -34,111 +40,118 @@ public final class PivotBusy_jsp extends org.apache.jasper.runtime.HttpJspBase
 
   private org.apache.jasper.runtime.TagHandlerPool _005fjspx_005ftagPool_005fc_005fout_0026_005fvalue_005fnobody;
 
-//  private javax.el.ExpressionFactory _el_expressionfactory;
+  //  private javax.el.ExpressionFactory _el_expressionfactory;
 
   public Object getDependants() {
     return _jspx_dependants;
   }
 
   public void _jspInit() {
-    _005fjspx_005ftagPool_005fc_005fout_0026_005fvalue_005fnobody = org.apache.jasper.runtime.TagHandlerPool.getTagHandlerPool(getServletConfig());
-//    _el_expressionfactory = _jspxFactory.getJspApplicationContext(getServletConfig().getServletContext()).getExpressionFactory();
+    _005fjspx_005ftagPool_005fc_005fout_0026_005fvalue_005fnobody = org.apache.jasper.runtime.TagHandlerPool
+        .getTagHandlerPool( getServletConfig() );
+    //    _el_expressionfactory = _jspxFactory.getJspApplicationContext(getServletConfig().getServletContext()).getExpressionFactory();
   }
 
   public void _jspDestroy() {
     _005fjspx_005ftagPool_005fc_005fout_0026_005fvalue_005fnobody.release();
   }
 
-  public void _jspService(HttpServletRequest request, HttpServletResponse response)
-        throws java.io.IOException, ServletException {
+  public void _jspService( HttpServletRequest request, HttpServletResponse response )
+      throws java.io.IOException, ServletException {
 
     PageContext pageContext;
-      JspWriter out;
-      JspWriter _jspx_out = null;
+    JspWriter out;
+    JspWriter _jspx_out;
+    _jspx_out = null;
     PageContext _jspx_page_context = null;
 
-
     try {
-      response.setContentType("text/html;");
-      pageContext = _jspxFactory.getPageContext(this, request, response,
-                                                            null, true, 8192, true);
+      response.setContentType( "text/html;" );
+      pageContext = _jspxFactory.getPageContext( this, request, response, null, true, 8192, true );
       _jspx_page_context = pageContext;
       out = pageContext.getOut();
       _jspx_out = out;
 
+      response.setCharacterEncoding( LocaleHelper.getSystemEncoding() );
 
-                    response.setCharacterEncoding(LocaleHelper.getSystemEncoding());
-
-      out.write("<html>\r\n");
-      out.write("<head>\r\n");
-      out.write("  <title>JPivot is busy ...</title>\r\n");
-      out.write("  <meta http-equiv=\"refresh\" content=\"1; URL=");
-      if (_jspx_meth_c_005fout_005f0(_jspx_page_context))
+      out.write( "<html>\r\n" );
+      out.write( "<head>\r\n" );
+      out.write( "  <title>JPivot is busy ...</title>\r\n" );
+      out.write( "  <meta http-equiv=\"refresh\" content=\"1; URL=" );
+      if ( _jspx_meth_c_005fout_005f0( _jspx_page_context ) ) {
         return;
-      out.write("\">\r\n");
-      out.write("</head>\r\n");
-      out.write("<body bgcolor=\"white\" dir=\"");
+      }
+      out.write( "\">\r\n" );
+      out.write( "</head>\r\n" );
+      out.write( "<body bgcolor=\"white\" dir=\"" );
       out.print( LocaleHelper.getSystemEncoding() );
-      out.write("\">\r\n");
-      out.write("\r\n");
-      out.write("  <h2>JPivot is busy ...</h2>\r\n");
-      out.write("\r\n");
-      out.write("  Please wait until your results are computed. Click\r\n");
-      out.write("  <a href=\"");
-      if (_jspx_meth_c_005fout_005f1(_jspx_page_context))
+      out.write( "\">\r\n" );
+      out.write( "\r\n" );
+      out.write( "  <h2>JPivot is busy ...</h2>\r\n" );
+      out.write( "\r\n" );
+      out.write( "  Please wait until your results are computed. Click\r\n" );
+      out.write( "  <a href=\"" );
+      if ( _jspx_meth_c_005fout_005f1( _jspx_page_context ) ) {
         return;
-      out.write("\">here</a>\r\n");
-      out.write("  if your browser does not support redirects.\r\n");
-      out.write("\r\n");
-      out.write("</body>\r\n");
-      out.write("</html>\r\n");
-    } catch (Throwable t) {
-      if (!(t instanceof SkipPageException)){
+      }
+      out.write( "\">here</a>\r\n" );
+      out.write( "  if your browser does not support redirects.\r\n" );
+      out.write( "\r\n" );
+      out.write( "</body>\r\n" );
+      out.write( "</html>\r\n" );
+    } catch ( Throwable t ) {
+      if ( !( t instanceof SkipPageException ) ) {
         out = _jspx_out;
-        if (out != null && out.getBufferSize() != 0)
-          try { out.clearBuffer(); } catch (java.io.IOException e) {}
-        if (_jspx_page_context != null) _jspx_page_context.handlePageException(t);
+        if ( out != null && out.getBufferSize() != 0 ) {
+          try {
+            out.clearBuffer();
+          } catch ( java.io.IOException e ) {
+          }
+        }
+        if ( _jspx_page_context != null ) {
+          _jspx_page_context.handlePageException( t );
+        }
       }
     } finally {
-      _jspxFactory.releasePageContext(_jspx_page_context);
+      _jspxFactory.releasePageContext( _jspx_page_context );
     }
   }
 
-  private boolean _jspx_meth_c_005fout_005f0(PageContext _jspx_page_context)
-          throws Throwable {
+  private boolean _jspx_meth_c_005fout_005f0( PageContext _jspx_page_context ) throws Throwable {
     PageContext pageContext = _jspx_page_context;
     JspWriter out = _jspx_page_context.getOut();
     //  c:out
-    org.apache.taglibs.standard.tag.rt.core.OutTag _jspx_th_c_005fout_005f0 = (org.apache.taglibs.standard.tag.rt.core.OutTag) _005fjspx_005ftagPool_005fc_005fout_0026_005fvalue_005fnobody.get(org.apache.taglibs.standard.tag.rt.core.OutTag.class);
-    _jspx_th_c_005fout_005f0.setPageContext(_jspx_page_context);
-    _jspx_th_c_005fout_005f0.setParent(null);
+    org.apache.taglibs.standard.tag.rt.core.OutTag _jspx_th_c_005fout_005f0 = (org.apache.taglibs.standard.tag.rt.core.OutTag) _005fjspx_005ftagPool_005fc_005fout_0026_005fvalue_005fnobody
+        .get( org.apache.taglibs.standard.tag.rt.core.OutTag.class );
+    _jspx_th_c_005fout_005f0.setPageContext( _jspx_page_context );
+    _jspx_th_c_005fout_005f0.setParent( null );
     // /jsp/PivotBusy.jsp(9,45) name = value type = java.lang.String reqTime = false required = true fragment = false deferredValue = false expectedTypeName = null deferredMethod = false methodSignature = null
-    _jspx_th_c_005fout_005f0.setValue("${requestSynchronizer.resultURI}");
+    _jspx_th_c_005fout_005f0.setValue( "${requestSynchronizer.resultURI}" );
     int _jspx_eval_c_005fout_005f0 = _jspx_th_c_005fout_005f0.doStartTag();
-    if (_jspx_th_c_005fout_005f0.doEndTag() == javax.servlet.jsp.tagext.Tag.SKIP_PAGE) {
-      _005fjspx_005ftagPool_005fc_005fout_0026_005fvalue_005fnobody.reuse(_jspx_th_c_005fout_005f0);
+    if ( _jspx_th_c_005fout_005f0.doEndTag() == javax.servlet.jsp.tagext.Tag.SKIP_PAGE ) {
+      _005fjspx_005ftagPool_005fc_005fout_0026_005fvalue_005fnobody.reuse( _jspx_th_c_005fout_005f0 );
       return true;
     }
-    _005fjspx_005ftagPool_005fc_005fout_0026_005fvalue_005fnobody.reuse(_jspx_th_c_005fout_005f0);
+    _005fjspx_005ftagPool_005fc_005fout_0026_005fvalue_005fnobody.reuse( _jspx_th_c_005fout_005f0 );
     return false;
   }
 
-  private boolean _jspx_meth_c_005fout_005f1(PageContext _jspx_page_context)
-          throws Throwable {
+  private boolean _jspx_meth_c_005fout_005f1( PageContext _jspx_page_context ) throws Throwable {
     PageContext pageContext = _jspx_page_context;
     JspWriter out = _jspx_page_context.getOut();
     //  c:out
-    org.apache.taglibs.standard.tag.rt.core.OutTag _jspx_th_c_005fout_005f1 = (org.apache.taglibs.standard.tag.rt.core.OutTag) _005fjspx_005ftagPool_005fc_005fout_0026_005fvalue_005fnobody.get(org.apache.taglibs.standard.tag.rt.core.OutTag.class);
-    _jspx_th_c_005fout_005f1.setPageContext(_jspx_page_context);
-    _jspx_th_c_005fout_005f1.setParent(null);
+    org.apache.taglibs.standard.tag.rt.core.OutTag _jspx_th_c_005fout_005f1 = (org.apache.taglibs.standard.tag.rt.core.OutTag) _005fjspx_005ftagPool_005fc_005fout_0026_005fvalue_005fnobody
+        .get( org.apache.taglibs.standard.tag.rt.core.OutTag.class );
+    _jspx_th_c_005fout_005f1.setPageContext( _jspx_page_context );
+    _jspx_th_c_005fout_005f1.setParent( null );
     // /jsp/PivotBusy.jsp(16,11) name = value type = java.lang.String reqTime = false required = true fragment = false deferredValue = false expectedTypeName = null deferredMethod = false methodSignature = null
-    _jspx_th_c_005fout_005f1.setValue("${requestSynchronizer.resultURI}");
+    _jspx_th_c_005fout_005f1.setValue( "${requestSynchronizer.resultURI}" );
     int _jspx_eval_c_005fout_005f1 = _jspx_th_c_005fout_005f1.doStartTag();
-    if (_jspx_th_c_005fout_005f1.doEndTag() == javax.servlet.jsp.tagext.Tag.SKIP_PAGE) {
-      _005fjspx_005ftagPool_005fc_005fout_0026_005fvalue_005fnobody.reuse(_jspx_th_c_005fout_005f1);
+    if ( _jspx_th_c_005fout_005f1.doEndTag() == javax.servlet.jsp.tagext.Tag.SKIP_PAGE ) {
+      _005fjspx_005ftagPool_005fc_005fout_0026_005fvalue_005fnobody.reuse( _jspx_th_c_005fout_005f1 );
       return true;
     }
-    _005fjspx_005ftagPool_005fc_005fout_0026_005fvalue_005fnobody.reuse(_jspx_th_c_005fout_005f1);
+    _005fjspx_005ftagPool_005fc_005fout_0026_005fvalue_005fnobody.reuse( _jspx_th_c_005fout_005f1 );
     return false;
   }
 }


### PR DESCRIPTION
@rfellows, @pamval,  @mdamour1976, here is backport of https://github.com/pentaho/pentaho-platform-plugin-jpivot/pull/49 to 6.1. PR for the platform is here: https://github.com/pentaho/pentaho-platform/pull/3223. Thanks.  