### PR TITLE
Fix button sizes: let browser calculate size

### DIFF
--- a/package-res/WEB-INF/jpivot/navi/hierarchy-navigator.xsl
+++ b/package-res/WEB-INF/jpivot/navi/hierarchy-navigator.xsl
@@ -28,18 +28,18 @@
           <table border="0" cellspacing="0" cellpadding="0" width="100%">
             <tr>
               <th align="left" class="navi-axis">
-                <img src="{$context}/jpivot/navi/{@icon}" width="9" height="9"/>
+                <img src="{$context}/jpivot/navi/{@icon}"/>
                 <xsl:text> </xsl:text>
                 <xsl:value-of select="@name"/>
               </th>
               <td align="right" class="xform-close-button">
-                <input type="image" src="{$context}/wcf/form/cancel.png" value="{../@cancel-title}" name="{../@cancel-id}" width="16" height="16"/>
+                <input type="image" src="{$context}/wcf/form/cancel.png" value="{../@cancel-title}" name="{../@cancel-id}"/>
               </td>
             </tr>
           </table>
         </xsl:when>
         <xsl:otherwise>
-          <img src="{$context}/jpivot/navi/{@icon}" width="9" height="9"/>
+          <img src="{$context}/jpivot/navi/{@icon}"/>
           <xsl:text> </xsl:text>
           <xsl:value-of select="@name"/>
         </xsl:otherwise>
@@ -84,12 +84,12 @@
 </xsl:template>
 
 <xsl:template match="cat-button[@icon]">
-  <input border="0" type="image" src="{$context}/jpivot/navi/{@icon}" name="{@id}" width="9" height="9"/>
+  <input border="0" type="image" src="{$context}/jpivot/navi/{@icon}" name="{@id}"/>
   <xsl:text> </xsl:text>
 </xsl:template>
 
 <xsl:template match="cat-button">
-  <img src="{$context}/jpivot/navi/empty.png" width="9" height="9"/>
+  <img src="{$context}/jpivot/navi/empty.png"/>
   <xsl:text> </xsl:text>
 </xsl:template>
 

--- a/package-res/WEB-INF/jpivot/table/fo_mdxtable.xsl
+++ b/package-res/WEB-INF/jpivot/table/fo_mdxtable.xsl
@@ -552,20 +552,20 @@ exclude-result-prefixes="fo">
 
 <!-- navigation: expand / collapse / leaf node -->
 <xsl:template match="drill-expand | drill-collapse">
-  <!--<input type="image" title="{@title}" name="{@id}" src="{$context}/{$imgpath}/{@img}.gif" border="0" width="9" height="9"/>-->
+  <!--<input type="image" title="{@title}" name="{@id}" src="{$context}/{$imgpath}/{@img}.gif" border="0"/>-->
 </xsl:template>
 
 <xsl:template match="drill-other">
-  <!--<img src="{$context}/{$imgpath}/{@img}.gif" border="0" width="9" height="9"/>-->
+  <!--<img src="{$context}/{$imgpath}/{@img}.gif" border="0"/>-->
 </xsl:template>
 
 <!-- navigation: sort -->
 <xsl:template match="sort">
-  <!--<input name="{@id}" title="{@title}" type="image" src="{$context}/{$imgpath}/{@mode}.gif" border="0" width="9" height="9"/>-->
+  <!--<input name="{@id}" title="{@title}" type="image" src="{$context}/{$imgpath}/{@mode}.gif" border="0"/>-->
 </xsl:template>
 
 <xsl:template match="drill-through">
-  <!--<input name="{@id}" title="{@title}" type="image" src="{$context}/{$imgpath}/drill-through.gif" border="0" width="9" height="9"/>-->
+  <!--<input name="{@id}" title="{@title}" type="image" src="{$context}/{$imgpath}/drill-through.gif" border="0"/>-->
 </xsl:template>
 
 

--- a/package-res/WEB-INF/jpivot/table/mdxtable.xsl
+++ b/package-res/WEB-INF/jpivot/table/mdxtable.xsl
@@ -99,20 +99,20 @@
 
 <!-- navigation: expand / collapse / leaf node -->
 <xsl:template match="drill-expand | drill-collapse">
-  <input type="image" title="{@title}" name="{@id}" src="{$context}/{$imgpath}/{@img}.gif" border="0" width="16" height="16"/>
+  <input type="image" title="{@title}" name="{@id}" src="{$context}/{$imgpath}/{@img}.gif" border="0"/>
 </xsl:template>
 
 <xsl:template match="drill-other">
-  <img src="{$context}/{$imgpath}/{@img}.gif" border="0" width="9" height="9"/>
+  <img src="{$context}/{$imgpath}/{@img}.gif" border="0"/>
 </xsl:template>
 
 <!-- navigation: sort -->
 <xsl:template match="sort">
-  <input name="{@id}" title="{@title}" type="image" src="{$context}/{$imgpath}/{@mode}.gif" border="0" width="9" height="9"/>
+  <input name="{@id}" title="{@title}" type="image" src="{$context}/{$imgpath}/{@mode}.gif" border="0"/>
 </xsl:template>
 
 <xsl:template match="drill-through">
-  <input name="{@id}" title="{@title}" type="image" src="{$context}/{$imgpath}/drill-through.gif" border="0" width="9" height="9"/>
+  <input name="{@id}" title="{@title}" type="image" src="{$context}/{$imgpath}/drill-through.gif" border="0"/>
 </xsl:template>
 
 

--- a/package-res/WEB-INF/jpivot/table/xls_mdxtable.xsl
+++ b/package-res/WEB-INF/jpivot/table/xls_mdxtable.xsl
@@ -243,21 +243,21 @@ xmlns:x="urn:schemas-microsoft-com:office:excel" >
 <!-- navigation: expand / collapse / leaf node -->
 
 <xsl:template match="drill-expand | drill-collapse">
- <!-- <input type="image" title="{@title}" name="{@id}" src="{$context}/{$imgpath}/{@img}.gif" border="0" width="9" height="9"/>-->
+ <!-- <input type="image" title="{@title}" name="{@id}" src="{$context}/{$imgpath}/{@img}.gif" border="0"/>-->
 </xsl:template>
 
 <xsl:template match="drill-other">
-  <!--<img src="{$context}/{$imgpath}/{@img}.gif" border="0" width="9" height="9"/>-->
+  <!--<img src="{$context}/{$imgpath}/{@img}.gif" border="0"/>-->
 </xsl:template>
 
 <!-- navigation: sort -->
 
 <xsl:template match="sort">
-  <!--<input name="{@id}" title="{@title}" type="image" src="{$context}/{$imgpath}/{@mode}.gif" border="0" width="9" height="9"/>-->
+  <!--<input name="{@id}" title="{@title}" type="image" src="{$context}/{$imgpath}/{@mode}.gif" border="0"/>-->
 </xsl:template>
 
 <xsl:template match="drill-through">
-  <!--<input name="{@id}" title="{@title}" type="image" src="{$context}/{$imgpath}/drill-through.gif" border="0" width="9" height="9"/>-->
+  <!--<input name="{@id}" title="{@title}" type="image" src="{$context}/{$imgpath}/drill-through.gif" border="0"/>-->
 </xsl:template>
 
 <!-- OPENOFFICE cell format -->

--- a/package-res/WEB-INF/jpivot/toolbar/htoolbar.xsl
+++ b/package-res/WEB-INF/jpivot/toolbar/htoolbar.xsl
@@ -18,7 +18,7 @@
 
 <xsl:template match="tool-button">
   <td>
-    <input type="image" name="{@id}" src="{$context}/{$imgpath}/{@img}.png" border="0" title="{@title}" width="24" height="24"/>
+    <input type="image" name="{@id}" src="{$context}/{$imgpath}/{@img}.png" border="0" title="{@title}"/>
   </td>
 </xsl:template>
 
@@ -34,7 +34,7 @@
       <xsl:if test="@target">
         <xsl:attribute name="target"><xsl:value-of select="@target"/></xsl:attribute>
       </xsl:if>
-      <img src="{$context}/{$imgpath}/{@img}.png" border="0" title="{@title}" width="24" height="24"/>
+      <img src="{$context}/{$imgpath}/{@img}.png" border="0" title="{@title}"/>
     </a>
   </td>
 </xsl:template>

--- a/package-res/WEB-INF/jpivot/toolbar/vtoolbar.xsl
+++ b/package-res/WEB-INF/jpivot/toolbar/vtoolbar.xsl
@@ -17,7 +17,7 @@
 <xsl:template match="tool-button">
   <tr>
     <td align="left">
-      <input type="image" name="{@id}" src="{$context}/{$imgpath}/{@img}.png" border="0" title="{@title}" width="24" height="24"/>
+      <input type="image" name="{@id}" src="{$context}/{$imgpath}/{@img}.png" border="0" title="{@title}"/>
     </td>
   </tr>
 </xsl:template>
@@ -37,7 +37,7 @@
         <xsl:if test="@target">
           <xsl:attribute name="target"><xsl:value-of select="@target"/></xsl:attribute>
         </xsl:if>
-        <img src="{$context}/{$imgpath}/{@img}.png" border="0" title="{@title}" width="24" height="24"/>
+        <img src="{$context}/{$imgpath}/{@img}.png" border="0" title="{@title}"/>
       </a>
     </td>
   </tr>

--- a/package-res/WEB-INF/wcf/catedit.xsl
+++ b/package-res/WEB-INF/wcf/catedit.xsl
@@ -10,7 +10,7 @@
 <xsl:template match="cat-category">
   <tr>
     <th align="left" class="navi-axis">
-      <img src="{$context}/wcf/catedit/{@icon}" width="9" height="9"/>
+      <img src="{$context}/wcf/catedit/{@icon}"/>
       <xsl:text> </xsl:text>
       <xsl:value-of select="@name"/>
     </th>
@@ -31,12 +31,12 @@
 </xsl:template>
 
 <xsl:template match="cat-button[@icon]">
-  <input border="0" type="image" src="{$context}/wcf/catedit/{@icon}" name="{@id}" width="9" height="9"/>
+  <input border="0" type="image" src="{$context}/wcf/catedit/{@icon}" name="{@id}"/>
   <xsl:text> </xsl:text>
 </xsl:template>
 
 <xsl:template match="cat-button">
-  <img src="{$context}/wcf/catedit/empty.png" width="9" height="9"/>
+  <img src="{$context}/wcf/catedit/empty.png"/>
   <xsl:text> </xsl:text>
 </xsl:template>
 

--- a/package-res/WEB-INF/wcf/changeorder.xsl
+++ b/package-res/WEB-INF/wcf/changeorder.xsl
@@ -2,31 +2,31 @@
 <xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
 
 <xsl:template match="move-button[@style='fwd']">
-  <input border="0" type="image" name="{@id}" src="{$context}/wcf/changeorder/move-down.png" width="9" height="9"/>
+  <input border="0" type="image" name="{@id}" src="{$context}/wcf/changeorder/move-down.png"/>
 </xsl:template>
 
 <xsl:template match="move-button[@style='bwd']">
-  <input border="0" type="image" name="{@id}" src="{$context}/wcf/changeorder/move-up.png" width="9" height="9"/>
+  <input border="0" type="image" name="{@id}" src="{$context}/wcf/changeorder/move-up.png"/>
 </xsl:template>
 
 <xsl:template match="move-button[@style='cut']">
-  <input border="0" type="image" name="{@id}" src="{$context}/wcf/changeorder/cut.png" width="9" height="9" title="{@title}"/>
+  <input border="0" type="image" name="{@id}" src="{$context}/wcf/changeorder/cut.png" title="{@title}"/>
 </xsl:template>
 
 <xsl:template match="move-button[@style='uncut']">
-  <input border="0" type="image" name="{@id}" src="{$context}/wcf/changeorder/uncut.png" width="9" height="9" title="{@title}"/>
+  <input border="0" type="image" name="{@id}" src="{$context}/wcf/changeorder/uncut.png" title="{@title}"/>
 </xsl:template>
 
 <xsl:template match="move-button[@style='paste-before']">
-  <input border="0" type="image" name="{@id}" src="{$context}/wcf/changeorder/paste-before.png" width="9" height="9" title="{@title}"/>
+  <input border="0" type="image" name="{@id}" src="{$context}/wcf/changeorder/paste-before.png" title="{@title}"/>
 </xsl:template>
 
 <xsl:template match="move-button[@style='paste-after']">
-  <input border="0" type="image" name="{@id}" src="{$context}/wcf/changeorder/paste-after.png" width="9" height="9" title="{@title}"/>
+  <input border="0" type="image" name="{@id}" src="{$context}/wcf/changeorder/paste-after.png" title="{@title}"/>
 </xsl:template>
 
 <xsl:template match="move-button">
-  <img src="{$context}/wcf/changeorder/move-empty.png" width="9" height="9"/>
+  <img src="{$context}/wcf/changeorder/move-empty.png"/>
 </xsl:template>
 
 </xsl:stylesheet>

--- a/package-res/WEB-INF/wcf/htoolbar.xsl
+++ b/package-res/WEB-INF/wcf/htoolbar.xsl
@@ -16,7 +16,7 @@
 
 <xsl:template match="tool-button">
   <td>
-    <input type="image" name="{@id}" src="{$context}/{$imgpath}/{@img}.png" border="0" title="{@title}" width="24" height="24"/>
+    <input type="image" name="{@id}" src="{$context}/{$imgpath}/{@img}.png" border="0" title="{@title}"/>
   </td>
 </xsl:template>
 
@@ -32,7 +32,7 @@
       <xsl:if test="@target">
         <xsl:attribute name="target"><xsl:value-of select="@target"/></xsl:attribute>
       </xsl:if>
-      <img src="{$context}/{$imgpath}/{@img}.png" border="0" title="{@title}" width="24" height="24"/>
+      <img src="{$context}/{$imgpath}/{@img}.png" border="0" title="{@title}"/>
     </a>
   </td>
 </xsl:template>

--- a/package-res/WEB-INF/wcf/vtoolbar.xsl
+++ b/package-res/WEB-INF/wcf/vtoolbar.xsl
@@ -15,7 +15,7 @@
 <xsl:template match="tool-button">
   <tr>
     <td align="left">
-      <input type="image" name="{@id}" src="{$context}/{$imgpath}/{@img}.png" border="0" title="{@title}" width="24" height="24"/>
+      <input type="image" name="{@id}" src="{$context}/{$imgpath}/{@img}.png" border="0" title="{@title}"/>
     </td>
   </tr>
 </xsl:template>
@@ -35,7 +35,7 @@
         <xsl:if test="@target">
           <xsl:attribute name="target"><xsl:value-of select="@target"/></xsl:attribute>
         </xsl:if>
-        <img src="{$context}/{$imgpath}/{@img}.png" border="0" title="{@title}" width="24" height="24"/>
+        <img src="{$context}/{$imgpath}/{@img}.png" border="0" title="{@title}"/>
       </a>
     </td>
   </tr>

--- a/package-res/WEB-INF/wcf/xtable.xsl
+++ b/package-res/WEB-INF/wcf/xtable.xsl
@@ -68,7 +68,7 @@ stylesheet for wcf table component
           <tr>
             <xsl:if test="@editId">
               <th align="left" class="xtable-title">
-                <input type="image" src="{$context}/wcf/table/edit.png" name="{@editId}" width="16" height="16"/>
+                <input type="image" src="{$context}/wcf/table/edit.png" name="{@editId}"/>
               </th>
             </xsl:if>
             <xsl:if test="@title">
@@ -79,7 +79,7 @@ stylesheet for wcf table component
             </xsl:if>
             <xsl:if test="@closeId">
               <td align="right" class="xtable-title">
-                <input type="image" src="{$context}/wcf/form/cancel.png" name="{@closeId}" width="16" height="16"/>
+                <input type="image" src="{$context}/wcf/form/cancel.png" name="{@closeId}"/>
               </td>
             </xsl:if>
           </tr>
@@ -144,7 +144,7 @@ stylesheet for wcf table component
       <xsl:with-param name="class">xtable-heading</xsl:with-param>
     </xsl:call-template>
     <xsl:apply-templates select="@colspan"/>
-    <input type="image" border="0" name="{@selectId}" src="{$context}/wcf/table/select.png" width="16" height="16"/>
+    <input type="image" border="0" name="{@selectId}" src="{$context}/wcf/table/select.png"/>
     <xsl:apply-templates/>
   </th>
 </xsl:template>
@@ -154,7 +154,7 @@ stylesheet for wcf table component
     <xsl:call-template name="set-class">
       <xsl:with-param name="class">xtable-heading</xsl:with-param>
     </xsl:call-template>
-    <input type="image" border="0" name="{@id}" src="{$context}/wcf/table/sort-{@sort}.png" width="9" height="9"/>
+    <input type="image" border="0" name="{@id}" src="{$context}/wcf/table/sort-{@sort}.png"/>
     <xsl:text> </xsl:text>
     <xsl:apply-templates/>
   </th>
@@ -181,7 +181,7 @@ stylesheet for wcf table component
 </xsl:template>
 
 <xsl:template match="xpagenav">
-  <input type="image" border="0" name="{@id}" src="{$context}/wcf/table/page-{@direction}.png" width="16" height="16"/>
+  <input type="image" border="0" name="{@id}" src="{$context}/wcf/table/page-{@direction}.png"/>
 </xsl:template>
 
 <xsl:template match="xgotopage">
@@ -190,7 +190,7 @@ stylesheet for wcf table component
   <xsl:text> </xsl:text>
   <input type="text" name="{@inputId}" value="{@value}" maxlength="3" size="3"/>
   <xsl:text> </xsl:text>
-  <input type="image" border="0" name="{@buttonId}" src="{$context}/wcf/table/gotopage.png" width="16" height="16"/>
+  <input type="image" border="0" name="{@buttonId}" src="{$context}/wcf/table/gotopage.png"/>
 </xsl:template>
 
 </xsl:stylesheet>

--- a/package-res/WEB-INF/wcf/xtree.xsl
+++ b/package-res/WEB-INF/wcf/xtree.xsl
@@ -81,7 +81,7 @@
             </xsl:if>
             <xsl:if test="@closeId">
               <td align="right" class="xform-close-button">
-                <input type="image" src="{$context}/wcf/form/cancel.png" name="{@closeId}" width="16" height="16"/>
+                <input type="image" src="{$context}/wcf/form/cancel.png" name="{@closeId}"/>
               </td>
             </xsl:if>
           </tr>
@@ -123,16 +123,16 @@
         <!-- expand/collapse button -->
         <xsl:choose>
           <xsl:when test="@state='bounded'">
-            <input border="0" type="image" name="{@id}.unbound" src="{$context}/wcf/tree/unbound.png" width="9" height="9"/>
+            <input border="0" type="image" name="{@id}.unbound" src="{$context}/wcf/tree/unbound.png"/>
           </xsl:when>
           <xsl:when test="@state='expanded'">
-            <input border="0" type="image" name="{@id}.collapse" src="{$context}/wcf/tree/collapse.png" width="9" height="9"/>
+            <input border="0" type="image" name="{@id}.collapse" src="{$context}/wcf/tree/collapse.png"/>
           </xsl:when>
           <xsl:when test="@state='collapsed'">
-            <input border="0" type="image" name="{@id}.expand" src="{$context}/wcf/tree/expand.png" width="9" height="9"/>
+            <input border="0" type="image" name="{@id}.expand" src="{$context}/wcf/tree/expand.png"/>
           </xsl:when>
           <xsl:otherwise>
-            <img src="{$context}/wcf/tree/leaf.png" width="9" height="9"/>
+            <img src="{$context}/wcf/tree/leaf.png"/>
           </xsl:otherwise>
         </xsl:choose>
 
@@ -160,7 +160,7 @@
 
 <xsl:template match="delete-button">
   <xsl:text> </xsl:text>
-  <input type="image" border="0" name="{@id}" src="{$context}/wcf/tree/delete.png" width="9" height="9"/>
+  <input type="image" border="0" name="{@id}" src="{$context}/wcf/tree/delete.png"/>
 </xsl:template>
 
 <xsl:template match="buttons">


### PR DESCRIPTION
The explicit width and height attributes force the browser to maintain that exact size inclusive of border / padding / margin. Since the images are the correct size, we can rely on the browser to calculate the appropriate sizing - which is correct.

This will change the look from:

![screenshot from 2017-08-15 10-00-44](https://user-images.githubusercontent.com/6703966/29296939-c95bcef6-81a0-11e7-863d-bcbdd18fbe9d.png)

To:

![screenshot from 2017-08-15 10-00-11](https://user-images.githubusercontent.com/6703966/29296944-d215c8e4-81a0-11e7-8038-0af89587eb01.png)